### PR TITLE
Fix bugs related in non-integer ratios with thin

### DIFF
--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -710,9 +710,9 @@ class PTSampler(object):
 
     def _writeToFile(self, iter):
         """
-        Function to write chain file. File has 3+ndim columns,
-        the first is log-posterior (unweighted), log-likelihood,
-        and acceptance probability, followed by parameter values.
+        Function to write chain file. File has ndim+4 columns,
+        appended to the parameter values are log-posterior (unnormalized),
+        log-likelihood, acceptance rate, and PT acceptance rate.
 
         @param iter: Iteration of sampler
 

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -179,7 +179,7 @@ class PTSampler(object):
         self.neff = neff
         self.tstart = 0
 
-        N = int(maxIter / thin)
+        N = int(np.ceil(maxIter / thin))
 
         self._lnprob = np.zeros(N)
         self._lnlike = np.zeros(N)


### PR DESCRIPTION
This fixes #20.  Unfortunately, when `isave / thin` is not an integer `sampler._writeToFile` seems to write duplicate chain entries every `isave // thin` steps.  I'm working on a fix to that, which is why this PR is a draft

In all cases `sampler._chain` is correct.  It's the periodic writing to file, which is pretty arcane in its implementation that is the problem.