### PR TITLE
Fix sample-counting and resuming bugs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,9 +3,12 @@ max-line-length = 120
 max-complexity = 45
 ignore =
   E203
-  W503      # line break before binary operator; conflicts with black
-  E722      # bare except ok
-  E731      # lambda expressions ok
+  # line break before binary operator; conflicts with black
+  W503
+  # bare except ok
+  E722
+  # lambda expressions ok
+  E731
 exclude =
     .git
     .tox

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -300,12 +300,12 @@ class PTSampler(object):
 #                self.resumechain = np.loadtxt(self.fname)
 #                self.resumeLength = self.resumechain.shape[0]
             self._chainfile = open(self.fname, "a")
+            if (self.resumeLength % (self.isave/self.thin) != 0):
+                raise Exception("Old chain has {0} rows, which is not a multiple of isave/thin = {1}".format(self.resumeLength, self.isave/self.thin))
+            print("Resuming with", self.resumeLength, "samples from file representing", self.resumeLength*self.thin, "original samples")
         else:
             self._chainfile = open(self.fname, "w")
         self._chainfile.close()
-        if (self.resumeLength % (self.isave/self.thin) != 0):
-            raise Exception("Old chain has {0} rows, which is not a multiple of isave/thin = {1}".format(self.resumeLength, self.isave/self.thin))
-        print("Resuming with", self.resumeLength, "samples from file representing", self.resumeLength*self.thin, "original samples")
 
     def updateChains(self, p0, lnlike0, lnprob0, iter):
         """

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -472,6 +472,7 @@ class PTSampler(object):
                 lnprob0 = 1 / self.temp * lnlike0 + lp
 
         # record first values
+        self.tstart = time.time()
         self.updateChains(p0, lnlike0, lnprob0, i0)
 
         self.comm.barrier()
@@ -479,7 +480,6 @@ class PTSampler(object):
         # start iterations
         iter = i0
         
-        self.tstart = time.time()
         runComplete = False
         Neff = 0
         while runComplete is False:


### PR DESCRIPTION
Fix bugs #10 and #20 as described in #10.  In the usual case where `Niter` is a multiple of `isave`, all computed samples will be written out.  The run can be resumed with some larger `Niter` and the samples will be correctly counted.  If `Niter` is a multiple of `thin` but not of `isave`, the partial block of samples will be written at the end.  In this case you cannot resume without deleting this partial block by hand.  If `Niter` is not a multiple of `thin`, the extra samples will be computed but not written.of
Progress reports after resuming give the percentage of the new samples that have been computed, as well as the percentage of the total.