### PR TITLE
Bump python version to 3.8

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
 
     steps:
     - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub Workflow Status (event)](https://img.shields.io/github/workflow/status/jellis18/PTMCMCSampler/CI%20targets?label=CI%20Tests)](https://github.com/jellis18/PTMCMCSampler/actions/workflows/ci_test.yml)
 
 [![DOI](https://zenodo.org/badge/32821232.svg)](https://zenodo.org/badge/latestdoi/32821232)
-[![Python Versions](https://img.shields.io/badge/python-3.7%2C%203.8%2C%203.9%2C%203.10%2C%203.11-blue.svg)]()
+[![Python Versions](https://img.shields.io/badge/python-3.8%2C%203.9%2C%203.10%2C%203.11-blue.svg)]()
 [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/jellis18/PTMCMCSampler/blob/master/LICENSE)
 
 MPI enabled Parallel Tempering MCMC code written in Python.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ multi_line_output = 3
 
 [tool.black]
 line-length = 120
-target_version = ['py37', 'py38', 'py39', 'py310']
+target_version = ['py38', 'py39', 'py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description_content_type="text/markdown",
     package_data={"": ["README.md", "HISTORY.md"]},
     install_requires=["numpy>=1.16.3", "scipy>=1.2.0"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     extras_require={"mpi": ["mpi4py>=3.0.3"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -23,7 +23,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This drops support for python 3.7. The 'isort' package we use for pre-commit-hooks doesn't support python 3.7 anymore either, causing issues with our integration tests