### PR TITLE
 MSTI feature added, temp replaced by beta

### DIFF
--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -91,7 +91,7 @@ class PTSampler(object):
         outDir="./chains",
         verbose=True,
         resume=False,
-        seed=None ### This was set to NONE, causing reproducability issue when initializing????
+        seed=None
     ):
         # MPI initialization
         self.comm = comm
@@ -198,14 +198,37 @@ class PTSampler(object):
     ):
         """
         Initialize MCMC quantities
+        @param p0: Initial parameter vector
+        @param self.Niter: Number of iterations to use for T = 1 chain
+        @param Bmax: Maximum beta in ladder (default=1)
+        @param Bmin: Minimum beta in ladder (default=None)
+        @param ladder: User defined temperature/beta ladder. Either scheme accepted.
+        @param shape: Specifies shape of beta/temperature ladder if a ladder is not already given (default='geometric') 
+        @param Tmin: Minimum temperature in ladder (default=None)
+        @param Tmax: Maximum temperature in ladder (default=None)
+        @param Tskip: Number of steps between proposed temperature swaps (default=100)
+        @param isave: Write to file every isave samples (default=1000)
+        @param covUpdate: Number of iterations between AM covariance updates (default=1000)
+        @param SCAMweight: Weight of SCAM jumps in overall jump cycle (default=20)
+        @param AMweight: Weight of AM jumps in overall jump cycle (default=20)
+        @param DEweight: Weight of DE jumps in overall jump cycle (default=20)
+        @param NUTSweight: Weight of the NUTS jumps in jump cycle (default=20)
+        @param MALAweight: Weight of the MALA jumps in jump cycle (default=20)
+        @param HMCweight: Weight of the HMC jumps in jump cycle (default=20)
+        @param HMCstepsize: Step-size of the HMC jumps (default=0.1)
+        @param HMCsteps: Maximum number of steps in an HMC trajectory (default=300)
+        @param burn: Burn in time (DE jumps added after this iteration) (default=10000)
+        @param maxIter: Maximum number of iterations for high temperature chains
+                        (default=2*self.Niter)
+        @param self.thin: MCMC Samples are recorded every self.thin samples
+        @param i0: Iteration to start MCMC (if i0 !=0, do not re-initialize)
+        @param neff: Number of effective samples to collect before terminating
+        @param writeHotChains:
+        @param hotChain:
+        @param model_param_idx: A tuple of lists of indices for each model’s parameters in MSTI, 
+                        used to sift through the combined set of parameters in p0. (default=None) 
+        @param nameChainTemps: Reverts to temperature naming convention of chains (default=False)
 
-        @param maxIter: maximum number of iterations
-        @Bmax:
-        @Bmin:
-        @Tmin: minumum temperature to use in temperature ladder
-        @shape: 
-        @nameChainTemps:
-        @model_param_idx:
 
         """
         #breakpoint()
@@ -315,7 +338,7 @@ class PTSampler(object):
         # if self.n_metaparams == 8:
         #     #hotChain=True
         #     #writeHotChains=True
-        #     shape = 'linear'  #############################################should this be a self.shape?
+        #     shape = 'linear'  
             
         # if ladder given check if in temp or beta
         if self.ladder:
@@ -470,6 +493,7 @@ class PTSampler(object):
         @param self.Niter: Number of iterations to use for T = 1 chain
         @param Bmax: Maximum beta in ladder (default=1)
         @param Bmin: Minimum beta in ladder (default=None)
+        @param shape: Specifies shape of beta/temperature ladder if a ladder is not already given (default='geometric') 
         @param ladder: User defined temperature/beta ladder. Either scheme accepted
         @param Tmin: Minimum temperature in ladder (default=None)
         @param Tmax: Maximum temperature in ladder (default=None)
@@ -494,6 +518,7 @@ class PTSampler(object):
         @param hotChain:
         @param model_param_idx: A tuple of lists of indices for each model’s parameters in MSTI, 
                         used to sift through the combined set of parameters in p0. (default=None) 
+        @param nameChainTemps: Reverts to temperature naming convention of chains (default=False)
 
         """
 

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -54,8 +54,10 @@ class PTSampler(object):
     jump proposals with the ``addProposalToCycle`` fuction.
 
     @param ndim: number of dimensions in problem
-    @param logl: single log-likelihood function or tuple of log-likelihood functions if using MSTI
-    @param logp: single log prior function (must be normalized for evidence evaluation) or tuple of log prior functions if using MSTI
+    @param logl: single log-likelihood function or tuple of log-likelihood functions if 
+    using MSTI
+    @param logp: single log prior function (must be normalized for evidence evaluation) or 
+    tuple of log prior functions if using MSTI
     @param cov: Initial covariance matrix of model parameters for jump proposals
     @param covinds: Indices of parameters for which to perform adaptive jumps
     @param loglargs: any additional arguments (apart from the parameter vector) for
@@ -107,14 +109,18 @@ class PTSampler(object):
         self.stream = self.comm.scatter(self.stream, root=0)
 
         self.ndim = ndim
-        
-        if (type(logl) is tuple) and (type(logp) is tuple): # if 2 loglikelihood functions and 2 log prior functions are supplied (MSTI)
+
+        # if 2 loglikelihood functions and 2 log prior functions are supplied (MSTI)
+        if (type(logl) is tuple) and (type(logp) is tuple): 
             self.logl1 = _function_wrapper(logl[1], loglargs, loglkwargs)  # model
             self.logl2 = _function_wrapper(logl[0], loglargs, loglkwargs)  # smbhb
             self.logp1 = _function_wrapper(logp[1], logpargs, logpkwargs)  # model
             self.logp2 = _function_wrapper(logp[0], logpargs, logpkwargs)  # smbhb
         elif (type(logl) is tuple) or (type(logp) is tuple): 
-            raise ValueError("You provided a tuple for either the loglikelihood or log prior but not the other. If you are using MSTI make sure both are tuples.")
+            raise ValueError(
+                "You provided a tuple for either the loglikelihood or log prior but not the other."
+                "If you are using MSTI make sure both are tuples."
+            )
         else:  # only 1 loglikelihood and 1 log prior provided
             self.logl = _function_wrapper(logl, loglargs, loglkwargs)
             self.logp = _function_wrapper(logp, logpargs, logpkwargs)
@@ -203,7 +209,8 @@ class PTSampler(object):
         @param Bmax: Maximum beta in ladder (default=1)
         @param Bmin: Minimum beta in ladder (default=None)
         @param ladder: User defined temperature/beta ladder. Either scheme accepted.
-        @param shape: Specifies shape of beta/temperature ladder if a ladder is not already given (default='geometric') 
+        @param shape: Specifies shape of beta/temperature ladder if a ladder is not already given
+        (default='geometric')
         @param Tmin: Minimum temperature in ladder (default=None)
         @param Tmax: Maximum temperature in ladder (default=None)
         @param Tskip: Number of steps between proposed temperature swaps (default=100)
@@ -263,13 +270,21 @@ class PTSampler(object):
         self.n_metaparams = 4
         self.model_param_idx = model_param_idx
         
-        if self.model_param_idx == None:
+        if self.model_param_idx is None:
             if hasattr(self, 'logl1'):
-                raise ValueError("You have provided a likelihood and a prior function for each model but have not provided seperate parameter indices for the two models. For MSTI you must supply parameter indices for each model.")
+                raise ValueError(
+                    "You have provided a likelihood and a prior function for each model but have not"
+                    "provided separate parameter indices for the two models. For MSTI you must supply"
+                    "parameter indices for each model."
+                )
         
-        if self.model_param_idx != None:
+        if self.model_param_idx is not None:
             if hasattr(self, 'logl'):
-                raise ValueError("You have provided seperate parameter indices for two models but only provided one likelihood and one prior function. For MSTI you must supply one of each for each model.") 
+                raise ValueError(
+                    "You have provided seperate parameter indices for two models but only provided"
+                    "one likelihood and one prior function. For MSTI you must supply one of each"
+                    "for each model."
+                ) 
             self.n_metaparams = 8
             self._lnprob1 = np.zeros(N)
             self._lnlike1 = np.zeros(N)
@@ -486,7 +501,8 @@ class PTSampler(object):
         @param self.Niter: Number of iterations to use for T = 1 chain
         @param Bmax: Maximum beta in ladder (default=1)
         @param Bmin: Minimum beta in ladder (default=None)
-        @param shape: Specifies shape of beta/temperature ladder if a ladder is not already given (default='geometric') 
+        @param shape: Specifies shape of beta/temperature ladder if a ladder is not already 
+                    given (default='geometric') 
         @param ladder: User defined temperature/beta ladder. Either scheme accepted
         @param Tmin: Minimum temperature in ladder (default=None)
         @param Tmax: Maximum temperature in ladder (default=None)
@@ -566,13 +582,19 @@ class PTSampler(object):
 
         # if resuming, just start with first point in chain
         if self.resume and self.resumeLength > 0:
-            p0, lnlike0, lnprob0 = self.resumechain[0, :-self.n_metaparams], self.resumechain[0, -(self.n_metaparams-1)], self.resumechain[0, -self.n_metaparams]
+            p0 = self.resumechain[0, :-self.n_metaparams] 
+            lnlike0 = self.resumechain[0, -(self.n_metaparams-1)]
+            lnprob0 = self.resumechain[0, -self.n_metaparams]
             
             if self.n_metaparams == 8:
-                lnlike1, lnprob1, lnlike2, lnprob2 = self.resumechain[0, -(self.n_metaparams-3)], self.resumechain[0, -(self.n_metaparams-2)], self.resumechain[0, -(self.n_metaparams-5)], self.resumechain[0, -(self.n_metaparams-4)]   ###### Reorder these?
+                lnlike1 = self.resumechain[0, -(self.n_metaparams-3)] 
+                lnprob1 = self.resumechain[0, -(self.n_metaparams-2)]
+                lnlike2 = self.resumechain[0, -(self.n_metaparams-5)]
+                lnprob2 = self.resumechain[0, -(self.n_metaparams-4)]
                 
                 # record first values
-                self.updateChains(p0, lnlike0, lnprob0, i0, lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
+                self.updateChains(p0, lnlike0, lnprob0, i0, 
+                                  lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
                 
             else: 
                 # record first values
@@ -618,7 +640,8 @@ class PTSampler(object):
                     lnprob0 = self.beta * (lnlike0) + lnprob2
                     
                 # record first values
-                self.updateChains(p0, lnlike0, lnprob0, i0, lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
+                self.updateChains(p0, lnlike0, lnprob0, i0, 
+                                  lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
                 
             else:
                 raise ValueError("Unclear how many meta-parameters there should be.")
@@ -638,14 +661,19 @@ class PTSampler(object):
             if self.n_metaparams==4:
                 p0, lnlike0, lnprob0 = self.PTMCMCOneStep(p0, lnlike0, lnprob0, iter)
             elif self.n_metaparams==8:
-                p0, lnlike0, lnprob0, lnlike1, lnprob1, lnlike2, lnprob2 = self.PTMCMCOneStep(p0, lnlike0, lnprob0, iter, lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
+                p0, lnlike0, lnprob0, lnlike1, lnprob1, lnlike2, lnprob2 = self.PTMCMCOneStep(p0, lnlike0, lnprob0, 
+                                                                                              iter, 
+                                                                                              lnlike1=lnlike1, 
+                                                                                              lnprob1=lnprob1, 
+                                                                                              lnlike2=lnlike2, 
+                                                                                              lnprob2=lnprob2)
 
             # compute effective number of samples
             if iter % 1000 == 0 and iter > 2 * self.burn and self.MPIrank == 0:
                 try:
                     Neff = iter / max(
                         1,
-                        np.nanmax([acor.acor(self._chain[self.burn : (iter - 1), ii])[0] for ii in range(self.ndim)]),
+                        np.nanmax([acor.acor(self._chain[self.burn: (iter - 1), ii])[0] for ii in range(self.ndim)]),
                     )
                     # print('\n {0} effective samples'.format(Neff))
                 except NameError:
@@ -730,9 +758,15 @@ class PTSampler(object):
         # if resuming, just use previous chain points.  Use each one thin times to compensate for
         # thinning when they were written out
         if self.resume and self.resumeLength > 0 and iter < self.resumeLength*self.thin:
-            p0, lnlike0, lnprob0 = self.resumechain[0, :-n_metaparams], self.resumechain[0, -(n_metaparams-1)], self.resumechain[0, -n_metaparams]
+            p0 = self.resumechain[0, :-self.n_metaparams] 
+            lnlike0 = self.resumechain[0, -(self.n_metaparams-1)]
+            lnprob0 = self.resumechain[0, -self.n_metaparams]
+            
             if self.n_metaparams == 8:
-                lnlike1, lnprob1, lnlike2, lnprob2 = self.resumechain[0, -(n_metaparams-3)], self.resumechain[0, -(n_metaparams-2)], self.resumechain[0, -(n_metaparams-5)], self.resumechain[0, -(n_metaparams-4)]   ###### Reorder these?
+                lnlike1 = self.resumechain[0, -(self.n_metaparams-3)] 
+                lnprob1 = self.resumechain[0, -(self.n_metaparams-2)]
+                lnlike2 = self.resumechain[0, -(self.n_metaparams-5)]
+                lnprob2 = self.resumechain[0, -(self.n_metaparams-4)]
                 
             # update acceptance counter
             self.naccepted = iter * self.resumechain[iter//self.thin, -2]
@@ -772,9 +806,10 @@ class PTSampler(object):
                     newlnlike = newlnprob1-newlnprob2
                     
                     # ln posterior = beta * ln likelihood + ln prior
-                    ### ln prior is set to ln posterior of the second model
-                    ### ln likelihood is the difference between ln posterior of the first and second models
-                    newlnprob = self.beta * (newlnlike) + newlnprob2 #beta determines how much of newlnprob1 vs newlnprob2
+                    # ln prior is set to ln posterior of the second model
+                    # ln likelihood is the difference between ln posterior of the first and second models
+                    # beta determines how much of newlnprob1 vs newlnprob2
+                    newlnprob = self.beta * (newlnlike) + newlnprob2 
 
             # hastings step
             diff = newlnprob - lnprob0 + qxy
@@ -793,13 +828,14 @@ class PTSampler(object):
         
         # Update chains
         if self.n_metaparams == 8: # MSTI
-            self.updateChains(p0, lnlike0, lnprob0, iter, lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
+            self.updateChains(p0, lnlike0, lnprob0, iter, 
+                              lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
             return p0, lnlike0, lnprob0, lnlike1, lnprob1, lnlike2, lnprob2
             
         else:
             # temperature swap
             if iter % self.Tskip == 0 and self.nchain > 1: 
-                p0, lnlike0, lnprob0 = self.PTswap(p0, lnlike0, lnprob0, iter) # No temperature swap for model-switch TI
+                p0, lnlike0, lnprob0 = self.PTswap(p0, lnlike0, lnprob0, iter) # No temperature swap for MSTI
             
             self.updateChains(p0, lnlike0, lnprob0, iter)
             
@@ -907,9 +943,12 @@ class PTSampler(object):
                 
                 elif tstep is None and Bmin is not None:
                     if Bmin == 0:
-                        warnings.warn("Bmin set to 0. Geometric series can only approach beta=0. Make sure to include the hot chain to get a beta=0 chain if you haven't already. Bmin will be set to 1e-7.")
+                        warnings.warn(
+                            "Bmin set to 0. Geometric series can only approach beta=0. Make sure to include the"
+                            "hot chain to get a beta=0 chain if you haven't already. Bmin will be set to 1e-7."
+                        )
                         Bmin = 1e-7
-                    tstep = np.exp(np.log(Bmin / Bmax) / (1-self.nchain))   ### Bmin can't be 0 here
+                    tstep = np.exp(np.log(Bmin / Bmax) / (1-self.nchain))   # Bmin can't be 0 here
                 
                 ladder = np.zeros(self.nchain)
                 for ii in range(self.nchain):
@@ -947,7 +986,9 @@ class PTSampler(object):
             self._chainfile.write("\t%f\t%f" % (self._lnprob[ind], self._lnlike[ind]))
             
             if self.n_metaparams == 8: # MSTI
-                self._chainfile.write("\t%f\t%f\t%f\t%f" % (self._lnprob1[ind], self._lnlike1[ind], self._lnprob2[ind], self._lnlike2[ind]))
+                self._chainfile.write("\t%f\t%f\t%f\t%f" % (
+                    self._lnprob1[ind], self._lnlike1[ind], self._lnprob2[ind], self._lnlike2[ind]
+                ))
                 
             self._chainfile.write("\t%f\t%f\n" % (self.naccepted / iter if iter > 0 else 0, pt_acc))
             
@@ -1023,7 +1064,7 @@ class PTSampler(object):
         """
 
         self._DEbuffer = shift_array(self._DEbuffer, -len(self._AMbuffer))  # shift DEbuffer to the left
-        self._DEbuffer[-len(self._AMbuffer) :] = self._AMbuffer  # add new samples to the new empty spaces
+        self._DEbuffer[-len(self._AMbuffer):] = self._AMbuffer  # add new samples to the new empty spaces
 
     # SCAM jump
     def covarianceJumpProposalSCAM(self, x, iter, beta): 
@@ -1176,7 +1217,7 @@ class PTSampler(object):
             nn = self.stream.integers(0, bufsize)
 
         # get jump scale size
-        prob = self.stream.random()
+        # prob = self.stream.random()
 
         # mode jump    
         # if prob > 0.5:

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -50,7 +50,7 @@ class PTSampler(object):
 
     Along with the AM and DE jumps, the user can add custom
     jump proposals with the ``addProposalToCycle`` fuction.
-    
+
     The user can also choose to perform Model-Switch Thermodynamic
     Integration (MSTI), which uses the Parallel Tempering aspect
     of PTMCMC to sample from varying mixtures of two models'
@@ -116,8 +116,8 @@ class PTSampler(object):
         # if 2 loglikelihood functions and 2 log prior functions are supplied (MSTI)
         if (type(logl) is tuple) and (type(logp) is tuple):
             self.logl1 = _function_wrapper(logl[1], loglargs, loglkwargs)
-            self.logl2 = _function_wrapper(logl[0], loglargs, loglkwargs) 
-            self.logp1 = _function_wrapper(logp[1], logpargs, logpkwargs) 
+            self.logl2 = _function_wrapper(logl[0], loglargs, loglkwargs)
+            self.logp1 = _function_wrapper(logp[1], logpargs, logpkwargs)
             self.logp2 = _function_wrapper(logp[0], logpargs, logpkwargs)
         elif (type(logl) is tuple) or (type(logp) is tuple):
             raise ValueError(
@@ -202,7 +202,7 @@ class PTSampler(object):
         neff=None,
         writeHotChains=False,
         hotChain=False,
-        MSTI=False
+        MSTI=False,
         nameChainTemps=False,
         model_param_idx=None,
     ):
@@ -274,21 +274,22 @@ class PTSampler(object):
         self.swapProposed = 0
         self.nswap_accepted = 0
         self.n_metaparams = 4
+        self.MSTI = MSTI
         self.model_param_idx = model_param_idx
 
         if not self.MSTI:
             if hasattr(self, "logl1"):
                 raise ValueError(
                     "You have provided a likelihood and a prior function for two models but have"
-                    "indicated that MSTI should not be performed."
+                    " indicated that MSTI should not be performed."
                 )
 
         if self.MSTI:
             if hasattr(self, "logl"):
                 raise ValueError(
                     "You have indicated that MSTI should be performed but have only provided"
-                    "one likelihood and one prior function. For MSTI you must supply one of each"
-                    "for each model."
+                    " one likelihood and one prior function. For MSTI you must supply one of each"
+                    " for each model."
                 )
             self.n_metaparams = 8
             self._lnprob1 = np.zeros(N)
@@ -603,6 +604,7 @@ class PTSampler(object):
                 neff=neff,
                 writeHotChains=writeHotChains,
                 hotChain=hotChain,
+                MSTI=MSTI,
                 model_param_idx=model_param_idx,
                 nameChainTemps=nameChainTemps,
             )
@@ -639,7 +641,7 @@ class PTSampler(object):
                 if self.model_param_idx:
                     y1 = [p0[idx] for idx in self.model_param_idx[1]]
                     y2 = [p0[idx] for idx in self.model_param_idx[0]]
-                    
+
                 else:
                     y1 = p0
                     y2 = p0
@@ -827,14 +829,14 @@ class PTSampler(object):
                     newlnprob = self.beta * newlnlike + lp
 
             elif self.MSTI:  # Using MSTI
-            
+
                 if self.model_param_idx:
                     y1 = [y[idx] for idx in self.model_param_idx[1]]
                     y2 = [y[idx] for idx in self.model_param_idx[0]]
 
                 else:
-                    y1 = p0
-                    y2 = p0
+                    y1 = y
+                    y2 = y
 
                 lp1 = self.logp1(y1)
                 lp2 = self.logp2(y2)
@@ -902,7 +904,7 @@ class PTSampler(object):
 
     def PTswap(self, p0, lnlike0, lnprob0, iter):
         """
-        Do parallel tempering swap. This feature is not compatible with 
+        Do parallel tempering swap. This feature is not compatible with
         Model-Switch Thermodynamic Integraton (MSTI)
 
         (Repurposed from Neil Cornish/Bence Becsy's code)

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -622,10 +622,6 @@ class PTSampler(object):
                 
             else:
                 raise ValueError("Unclear how many meta-parameters there should be.")
- 
-
-        # # record first values
-        # self.updateChains(p0, lnlike0, lnprob0, i0)
 
         self.comm.barrier()
 
@@ -813,7 +809,16 @@ class PTSampler(object):
     def PTswap(self, p0, lnlike0, lnprob0, iter):
         """
         Do parallel tempering swap. This feature is not compatible with MSTI
-
+        
+        (Repurposed from Neil Cornish/Bence Becsy's code)
+        
+        Swap acceptance rates are computed per chain by storing
+        the number of swaps proposed and accepted. Since swaps
+        are proposed for every chain, swapProposed is always
+        incremented and nswap_accepted will be incremented only
+        for chains that have the swap accepted. The swap acceptance
+        is calculated elsewhere.
+        
         @param p0: current parameter vector
         @param lnlike0: current log-likelihood
         @param lnprob0: current log posterior value
@@ -827,7 +832,6 @@ class PTSampler(object):
         @return lnlike0: new log-likelihood
         @return lnprob0: new log posterior value
 
-        Repurposed from Neil Cornish/Bence Becsy's code:
         """
         Ts = self.ladder # as beta
 

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -6,6 +6,8 @@ import numpy as np
 
 from .nutsjump import HMCJump, MALAJump, NUTSJump
 
+import warnings
+
 try:
     from mpi4py import MPI
 except ImportError:
@@ -52,8 +54,8 @@ class PTSampler(object):
     jump proposals with the ``addProposalToCycle`` fuction.
 
     @param ndim: number of dimensions in problem
-    @param logl: log-likelihood function
-    @param logp: log prior function (must be normalized for evidence evaluation)
+    @param logl: single log-likelihood function or tuple of log-likelihood functions if using MSTI
+    @param logp: single log prior function (must be normalized for evidence evaluation) or tuple of log prior functions if using MSTI
     @param cov: Initial covariance matrix of model parameters for jump proposals
     @param covinds: Indices of parameters for which to perform adaptive jumps
     @param loglargs: any additional arguments (apart from the parameter vector) for
@@ -89,7 +91,7 @@ class PTSampler(object):
         outDir="./chains",
         verbose=True,
         resume=False,
-        seed=None,
+        seed=None ### This was set to NONE, causing reproducability issue when initializing????
     ):
         # MPI initialization
         self.comm = comm
@@ -105,8 +107,18 @@ class PTSampler(object):
         self.stream = self.comm.scatter(self.stream, root=0)
 
         self.ndim = ndim
-        self.logl = _function_wrapper(logl, loglargs, loglkwargs)
-        self.logp = _function_wrapper(logp, logpargs, logpkwargs)
+        
+        if (type(logl) is tuple) and (type(logp) is tuple): # if 2 loglikelihood functions and 2 log prior functions are supplied (MSTI)
+            self.logl1 = _function_wrapper(logl[1], loglargs, loglkwargs)  # model
+            self.logl2 = _function_wrapper(logl[0], loglargs, loglkwargs)  # smbhb
+            self.logp1 = _function_wrapper(logp[1], logpargs, logpkwargs)  # model
+            self.logp2 = _function_wrapper(logp[0], logpargs, logpkwargs)  # smbhb
+        elif (type(logl) is tuple) or (type(logp) is tuple): 
+            raise ValueError("You provided a tuple for either the loglikelihood or log prior but not the other. If you are using MSTI make sure both are tuples.")
+        else:  # only 1 loglikelihood and 1 log prior provided
+            self.logl = _function_wrapper(logl, loglargs, loglkwargs)
+            self.logp = _function_wrapper(logp, logpargs, logpkwargs)
+            
         if logl_grad is not None and logp_grad is not None:
             self.logl_grad = _function_wrapper(logl_grad, loglargs, loglkwargs)
             self.logp_grad = _function_wrapper(logp_grad, logpargs, logpkwargs)
@@ -158,7 +170,10 @@ class PTSampler(object):
         self,
         Niter,
         ladder=None,
-        Tmin=1,
+        shape='geometric',
+        Bmax=1,
+        Bmin=None,
+        Tmin=None,
         Tmax=None,
         Tskip=100,
         isave=1000,
@@ -175,23 +190,32 @@ class PTSampler(object):
         maxIter=None,
         thin=10,
         i0=0,
-        neff=None,
+        neff=100000,
         writeHotChains=False,
         hotChain=False,
+        nameChainTemps=False,
+        model_param_idx=None
     ):
         """
         Initialize MCMC quantities
 
         @param maxIter: maximum number of iterations
+        @Bmax:
+        @Bmin:
         @Tmin: minumum temperature to use in temperature ladder
+        @shape: 
+        @nameChainTemps:
+        @model_param_idx:
 
         """
+        #breakpoint()
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
             maxIter = Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
-
+        
+        
         self.ladder = ladder
         self.covUpdate = covUpdate
         self.SCAMweight = SCAMweight
@@ -205,15 +229,32 @@ class PTSampler(object):
         self.neff = neff
         self.tstart = 0
 
-        N = int(maxIter / thin) + 1  # first sample + those we generate
+        N = int(maxIter / thin) + 1 # first sample + those we generate
 
         self._lnprob = np.zeros(N)
         self._lnlike = np.zeros(N)
         self._chain = np.zeros((N, self.ndim))
-        self.ind_next_write = 0  # Next index in these arrays to write out
+        self.ind_next_write = 0    # Next index in these arrays to write out
         self.naccepted = 0
         self.swapProposed = 0
         self.nswap_accepted = 0
+        self.n_metaparams = 4
+        self.model_param_idx = model_param_idx
+        
+        if self.model_param_idx == None:
+            if hasattr(self, 'logl1'):
+                raise ValueError("You have provided a likelihood and a prior function for each model but have not provided seperate parameter indices for the two models. For MSTI you must supply parameter indices for each model.")
+        
+        if self.model_param_idx != None:
+            if hasattr(self, 'logl'):
+                raise ValueError("You have provided seperate parameter indices for two models but only provided one likelihood and one prior function. For MSTI you must supply one of each for each model.") 
+            self.n_metaparams = 8
+            self._lnprob1 = np.zeros(N)
+            self._lnlike1 = np.zeros(N)
+            self._lnprob2 = np.zeros(N)
+            self._lnlike2 = np.zeros(N)
+            
+        
 
         # set up covariance matrix and DE buffers
         if self.MPIrank == 0:
@@ -270,55 +311,71 @@ class PTSampler(object):
         # randomize cycle
         self.randomizeProposalCycle()
 
-        # setup default temperature ladder
-        if self.ladder is None:
-            self.ladder = self.temperatureLadder(Tmin, Tmax=Tmax)
-
-        # temperature for current chain
-        self.temp = self.ladder[self.MPIrank]
-
-        # hot chain sampling from prior
+        # Hot chains required for MSTI         
+        # if self.n_metaparams == 8:
+        #     #hotChain=True
+        #     #writeHotChains=True
+        #     shape = 'linear'  #############################################should this be a self.shape?
+            
+        # if ladder given check if in temp or beta
+        if self.ladder:
+            if any(self.ladder)>1:
+                # user gave temperatures >>> convert to beta
+                self.ladder = [1/temp for temp in self.ladder]
+        
+        # ladder not specified, create one        
+        else: 
+            # If temperatures are used, convert to beta
+            if Tmin: # used temperatures
+                Bmax = 1/Tmin #typically 1
+            if Tmax:
+                Bmin = 1/Tmax
+                
+            self.ladder = self.Ladder(Bmax, Bmin=Bmin, shape=shape)
+        
+        # beta for current chain
+        self.beta = self.ladder[self.MPIrank]
+            
+        
+        # Name chain files  
         if hotChain and self.MPIrank == self.nchain - 1:
-            self.temp = 1e80
-            self.fname = self.outDir + "/chain_hot.txt"
-        else:
-            self.fname = self.outDir + "/chain_{0}.txt".format(self.temp)
-
+            self.beta = 0  #This is the "hot chain"
+            if nameChainTemps:  # if you prefer the old naming scheme
+                self.fname = self.outDir + "/chain_hot.txt"
+            else:  # new naming scheme with beta
+                self.fname = self.outDir + "/chain_0.txt"
+        
+        elif nameChainTemps:  # if you prefer the old naming scheme
+            self.fname = self.outDir + "/chain_{0}.txt".format(1/self.beta)
+            
+        else:  # new naming scheme with beta
+            self.fname = self.outDir + "/chain_{0}.txt".format(self.beta)
+            
+            
         # write hot chains
         self.writeHotChains = writeHotChains
-
+        
+        
         self.resumeLength = 0
         if self.resume and os.path.isfile(self.fname):
             if self.verbose:
                 print("Resuming run from chain file {0}".format(self.fname))
             try:
-                self.resumechain = np.loadtxt(self.fname, ndmin=2)
-                self.resumeLength = self.resumechain.shape[0]  # Number of samples read from old chain
+                self.resumechain = np.loadtxt(self.fname)
+                self.resumeLength = self.resumechain.shape[0] # Number of samples read from old chain
             except ValueError as error:
                 print("Reading old chain files failed with error", error)
                 raise Exception("Couldn't read old chain to resume")
             self._chainfile = open(self.fname, "a")
-            if (
-                self.isave != self.thin
-                and self.resumeLength % (self.isave / self.thin) != 1  # This special case is always OK
-            ):  # Initial sample plus blocks of isave/thin
-                raise Exception(
-                    (
-                        "Old chain has {0} rows, which is not the initial sample plus a multiple of isave/thin = {1}"
-                    ).format(self.resumeLength, self.isave // self.thin)
-                )
-            print(
-                "Resuming with",
-                self.resumeLength,
-                "samples from file representing",
-                (self.resumeLength - 1) * self.thin + 1,
-                "original samples",
-            )
+            if (self.isave != self.thin and # This special case is always OK
+                self.resumeLength % (self.isave/self.thin) != 1): # Initial sample plus blocks of isave/thin
+                raise Exception("Old chain has {0} rows, which is not a multiple of isave/thin = {1}".format(self.resumeLength, self.isave//self.thin))
+            print("Resuming with", self.resumeLength, "samples from file representing", (self.resumeLength-1)*self.thin+1, "original samples")
         else:
             self._chainfile = open(self.fname, "w")
         self._chainfile.close()
 
-    def updateChains(self, p0, lnlike0, lnprob0, iter):
+    def updateChains(self, p0, lnlike0, lnprob0, iter, lnlike1=None, lnprob1=None, lnlike2=None, lnprob2=None):
         """
         Update chains after jump proposals
 
@@ -333,6 +390,12 @@ class PTSampler(object):
             self._chain[ind, :] = p0
             self._lnlike[ind] = lnlike0
             self._lnprob[ind] = lnprob0
+            
+            if lnlike1 and lnlike2 and lnprob1 and lnprob2:
+                self._lnlike1[ind] = lnlike1
+                self._lnprob1[ind] = lnprob1
+                self._lnlike2[ind] = lnlike2
+                self._lnprob2[ind] = lnprob2
 
         # write to file
         if iter % self.isave == 0:
@@ -343,6 +406,7 @@ class PTSampler(object):
         Write chains and covariance matrix.  Called every isave on samples or at end.
         """
         if iter // self.thin >= self.ind_next_write:
+
             if self.writeHotChains or self.MPIrank == 0:
                 self._writeToFile(iter)
 
@@ -351,32 +415,32 @@ class PTSampler(object):
                 np.save(self.outDir + "/cov.npy", self.cov)
 
             if self.MPIrank == 0 and self.verbose:
-                if iter > 0:
-                    sys.stdout.write("\r")
-                percent = iter / self.Niter * 100  # Percent of total work finished
+                if iter > 0: sys.stdout.write("\r")
+                percent = iter / self.Niter * 100 # Percent of total work finished
                 acceptance = self.naccepted / iter if iter > 0 else 0
                 elapsed = time.time() - self.tstart
                 if self.resume:
                     # Percentage of new work done
-                    percentnew = (
-                        (iter - self.resumeLength * self.thin) / (self.Niter - self.resumeLength * self.thin) * 100
-                    )
+                    percentnew = ((iter - self.resumeLength*self.thin)
+                                  / (self.Niter - self.resumeLength*self.thin) * 100)
                     sys.stdout.write(
                         "Finished %2.2f percent (%2.2f percent of new work) in %f s Acceptance rate = %g"
-                        % (percent, percentnew, elapsed, acceptance)
-                    )
+                        % (percent, percentnew, elapsed, acceptance))
                 else:
-                    sys.stdout.write(
-                        "Finished %2.2f percent in %f s Acceptance rate = %g" % (percent, elapsed, acceptance)
-                    )
+                    sys.stdout.write("Finished %2.2f percent in %f s Acceptance rate = %g"
+                                     % (percent, elapsed, acceptance)
+                )
                 sys.stdout.flush()
 
     def sample(
         self,
         p0,
         Niter,
+        Bmax=1,
+        Bmin=None,
         ladder=None,
-        Tmin=1,
+        shape='geometric',
+        Tmin=None,
         Tmax=None,
         Tskip=100,
         isave=1000,
@@ -393,17 +457,21 @@ class PTSampler(object):
         maxIter=None,
         thin=10,
         i0=0,
-        neff=None,
+        neff=100000,
         writeHotChains=False,
         hotChain=False,
+        model_param_idx=None,
+        nameChainTemps=False
     ):
         """
         Function to carry out PTMCMC sampling.
 
         @param p0: Initial parameter vector
         @param self.Niter: Number of iterations to use for T = 1 chain
-        @param ladder: User defined temperature ladder
-        @param Tmin: Minimum temperature in ladder (default=1)
+        @param Bmax: Maximum beta in ladder (default=1)
+        @param Bmin: Minimum beta in ladder (default=None)
+        @param ladder: User defined temperature/beta ladder. Either scheme accepted
+        @param Tmin: Minimum temperature in ladder (default=None)
         @param Tmax: Maximum temperature in ladder (default=None)
         @param Tskip: Number of steps between proposed temperature swaps (default=100)
         @param isave: Write to file every isave samples (default=1000)
@@ -422,6 +490,10 @@ class PTSampler(object):
         @param self.thin: MCMC Samples are recorded every self.thin samples
         @param i0: Iteration to start MCMC (if i0 !=0, do not re-initialize)
         @param neff: Number of effective samples to collect before terminating
+        @param writeHotChains:
+        @param hotChain:
+        @param model_param_idx: A tuple of lists of indices for each model’s parameters in MSTI, 
+                        used to sift through the combined set of parameters in p0. (default=None) 
 
         """
 
@@ -431,21 +503,22 @@ class PTSampler(object):
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 
-        if isave % thin != 0:
+        if (isave % thin != 0):
             raise ValueError("isave = %d is not a multiple of thin =  %d" % (isave, thin))
 
-        if Niter % thin != 0:
-            print(
-                "Niter = %d is not a multiple of thin = %d.  The last %d samples will be lost"
-                % (Niter, thin, Niter % thin)
-            )
+        if (Niter % thin != 0):
+            print("Niter = %d is not a multiple of thin = %d.  The last %d samples will be lost"
+                  % (Niter, thin, Niter % thin))
 
         # set up arrays to store lnprob, lnlike and chain
         # if picking up from previous run, don't re-initialize
         if i0 == 0:
             self.initialize(
                 Niter,
+                Bmax=Bmax,
+                Bmin=Bmin,
                 ladder=ladder,
+                shape=shape,
                 Tmin=Tmin,
                 Tmax=Tmax,
                 Tskip=Tskip,
@@ -466,68 +539,122 @@ class PTSampler(object):
                 neff=neff,
                 writeHotChains=writeHotChains,
                 hotChain=hotChain,
+                model_param_idx=model_param_idx,
+                nameChainTemps=nameChainTemps
             )
-
+            
+            
         # compute lnprob for initial point in chain
 
         # if resuming, just start with first point in chain
         if self.resume and self.resumeLength > 0:
-            p0, lnlike0, lnprob0 = self.resumechain[0, :-4], self.resumechain[0, -3], self.resumechain[0, -4]
+            p0, lnlike0, lnprob0 = self.resumechain[0, :-self.n_metaparams], self.resumechain[0, -(self.n_metaparams-1)], self.resumechain[0, -self.n_metaparams]
+            
+            if self.n_metaparams == 8:
+                lnlike1, lnprob1, lnlike2, lnprob2 = self.resumechain[0, -(self.n_metaparams-3)], self.resumechain[0, -(self.n_metaparams-2)], self.resumechain[0, -(self.n_metaparams-5)], self.resumechain[0, -(self.n_metaparams-4)]   ###### Reorder these?
+                
+                # record first values
+                self.updateChains(p0, lnlike0, lnprob0, i0, lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
+                
+            else: 
+                # record first values
+                self.updateChains(p0, lnlike0, lnprob0, i0)
+                
             self.ind_next_write = self.resumeLength
+            
+        
         else:
-            # compute prior
-            lp = self.logp(p0)
+            # compute prior and likelihood
+            if self.n_metaparams == 4: #model_param_idx == None:
+                lp = self.logp(p0)
 
-            if lp == float(-np.inf):
-                lnprob0 = -np.inf
-                lnlike0 = -np.inf
+                if lp == float(-np.inf):
+                    lnprob0 = -np.inf
 
+                else:
+                    lnlike0 = self.logl(p0)
+                    lnprob0 = self.beta * lnlike0 + lp
+                    
+                # record first values
+                self.updateChains(p0, lnlike0, lnprob0, i0)
+                    
+            elif self.n_metaparams == 8: #model_param_idx != None:  # Using model-switch TI
+                y1 = [p0[idx] for idx in model_param_idx[1]]
+                y2 = [p0[idx] for idx in model_param_idx[0]]
+                
+                lp1 = self.logp1(y1)
+                lp2 = self.logp2(y2)
+                
+                if lp1 == -np.inf or lp2 == -np.inf:
+                    lnprob0 = -np.inf
+                
+                else:    
+                    lnlike1 = self.logl1(y1)  # model
+                    lnprob1 = lnlike1 + lp1
+                     
+                    lnlike2 = self.logl2(y2)  # smbhb 
+                    lnprob2 = lnlike2 +lp2
+                    
+                    lnlike0 = lnprob1-lnprob2
+                    
+                    lnprob0 = self.beta * (lnlike0) + lnprob2
+                    
+                # record first values
+                self.updateChains(p0, lnlike0, lnprob0, i0, lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
+                
             else:
-                lnlike0 = self.logl(p0)
-                lnprob0 = 1 / self.temp * lnlike0 + lp
+                raise ValueError("Unclear how many meta-parameters there should be.")
+ 
 
-        # record first values
-        self.tstart = time.time()
-        self.updateChains(p0, lnlike0, lnprob0, i0)
+        # # record first values
+        # self.updateChains(p0, lnlike0, lnprob0, i0)
 
         self.comm.barrier()
 
         # start iterations
         iter = i0
-
+        
+        self.tstart = time.time()
         runComplete = False
+        Neff = 0
         while runComplete is False:
             iter += 1
             self.comm.barrier()  # make sure all processes are at the same iteration
             # call PTMCMCOneStep
-            p0, lnlike0, lnprob0 = self.PTMCMCOneStep(p0, lnlike0, lnprob0, iter)
+            if self.n_metaparams==4:
+                p0, lnlike0, lnprob0 = self.PTMCMCOneStep(p0, lnlike0, lnprob0, iter)
+            elif self.n_metaparams==8:
+                p0, lnlike0, lnprob0, lnlike1, lnprob1, lnlike2, lnprob2 = self.PTMCMCOneStep(p0, lnlike0, lnprob0, iter, lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
 
-            # rank 0 decides whether to stop
-            if self.MPIrank == 0:
-                if iter >= self.Niter:  # stop if reached maximum number of iterations
-                    message = "\nRun Complete"
-                    runComplete = True
-                elif self.neff:  # Stop if effective number of samples reached if requested
-                    if iter % 1000 == 0 and iter > 2 * self.burn and self.MPIrank == 0:
-                        Neff = iter / max(
-                            1,
-                            np.nanmax(
-                                [acor.acor(self._chain[self.burn : (iter - 1), ii])[0] for ii in range(self.ndim)]
-                            ),
-                        )
-                        # print('\n {0} effective samples'.format(Neff))
-                        if int(Neff) >= self.neff:
-                            message = "\nRun Complete with {0} effective samples".format(int(Neff))
-                            runComplete = True
+            # compute effective number of samples
+            if iter % 1000 == 0 and iter > 2 * self.burn and self.MPIrank == 0:
+                try:
+                    Neff = iter / max(
+                        1,
+                        np.nanmax([acor.acor(self._chain[self.burn : (iter - 1), ii])[0] for ii in range(self.ndim)]),
+                    )
+                    # print('\n {0} effective samples'.format(Neff))
+                except NameError:
+                    Neff = 0
+                    pass
 
-            runComplete = self.comm.bcast(runComplete, root=0)  # rank 0 tells others whether to stop
+            # stop if reached maximum number of iterations
+            if self.MPIrank == 0 and iter >= self.Niter:
+                self.writeOutput(iter) # Possibly write partial block
+                if self.verbose:
+                    print("\nRun Complete")
+                runComplete = True
 
-            if runComplete:
-                self.writeOutput(iter)  # Possibly write partial block
-                if self.MPIrank == 0 and self.verbose:
-                    print(message)
+            # stop if reached effective number of samples
+            if self.MPIrank == 0 and int(Neff) > self.neff:
+                self.writeOutput(iter) # Possibly write partial block
+                if self.verbose:
+                    print("\nRun Complete with {0} effective samples".format(int(Neff)))
+                runComplete = True
 
-    def PTMCMCOneStep(self, p0, lnlike0, lnprob0, iter):
+            runComplete = self.comm.bcast(runComplete, root=0)
+
+    def PTMCMCOneStep(self, p0, lnlike0, lnprob0, iter, lnlike1=None, lnprob1=None, lnlike2=None, lnprob2=None):
         """
         Function to carry out PTMCMC sampling.
 
@@ -588,58 +715,87 @@ class PTSampler(object):
 
         # if resuming, just use previous chain points.  Use each one thin times to compensate for
         # thinning when they were written out
-        if self.resume and self.resumeLength > 0 and iter < self.resumeLength * self.thin:
-            p0, lnlike0, lnprob0 = (
-                self.resumechain[iter // self.thin, :-4],
-                self.resumechain[iter // self.thin, -3],
-                self.resumechain[iter // self.thin, -4],
-            )
-
+        if self.resume and self.resumeLength > 0 and iter < self.resumeLength*self.thin:
+            p0, lnlike0, lnprob0 = self.resumechain[0, :-n_metaparams], self.resumechain[0, -(n_metaparams-1)], self.resumechain[0, -n_metaparams]
+            if self.n_metaparams == 8:
+                lnlike1, lnprob1, lnlike2, lnprob2 = self.resumechain[0, -(n_metaparams-3)], self.resumechain[0, -(n_metaparams-2)], self.resumechain[0, -(n_metaparams-5)], self.resumechain[0, -(n_metaparams-4)]   ###### Reorder these?
+                
             # update acceptance counter
-            self.naccepted = iter * self.resumechain[iter // self.thin, -2]
+            self.naccepted = iter * self.resumechain[iter//self.thin, -2]
         else:
-            y, qxy, jump_name = self._jump(p0, iter)
+            #breakpoint()
+            y, qxy, jump_name = self._jump(p0, iter) # made a jump
             self.jumpDict[jump_name][0] += 1
 
             # compute prior and likelihood
-            lp = self.logp(y)
+            if self.n_metaparams == 4:
+                lp = self.logp(y)
 
-            if lp == -np.inf:
-                newlnprob = -np.inf
+                if lp == -np.inf:
+                    newlnprob = -np.inf
 
-            else:
-                newlnlike = self.logl(y)
-                newlnprob = 1 / self.temp * newlnlike + lp
+                else:
+                    newlnlike = self.logl(y)
+                    newlnprob = self.beta * newlnlike + lp
+                    
+            elif self.n_metaparams == 8:  # Using MSTI
+        
+                y1 = [y[idx] for idx in self.model_param_idx[1]] # model
+                y2 = [y[idx] for idx in self.model_param_idx[0]] # smbhb
+                
+                lp1 = self.logp1(y1) # model
+                lp2 = self.logp2(y2) # smbhb
+                
+                if lp1 == -np.inf or lp2 == -np.inf:
+                    newlnprob = -np.inf
+                
+                else:    
+                    newlnlike1 = self.logl1(y1)  # model
+                    newlnprob1 = newlnlike1 + lp1  # no beta here, we want full posterior
+                     
+                    newlnlike2 = self.logl2(y2)  # smbhb 
+                    newlnprob2 = newlnlike2 +lp2  # no beta here, we want full posterior
+                    
+                    newlnlike = newlnprob1-newlnprob2
+                    
+                    # ln posterior = beta * ln likelihood + ln prior
+                    ### ln prior is set to ln posterior of the second model
+                    ### ln likelihood is the difference between ln posterior of the first and second models
+                    newlnprob = self.beta * (newlnlike) + newlnprob2 #beta determines how much of newlnprob1 vs newlnprob2
 
             # hastings step
             diff = newlnprob - lnprob0 + qxy
-            if diff > np.log(self.stream.random()):
+            
+            rand_log = np.log(self.stream.random())
+            if diff > rand_log:
+                        
                 # accept jump
                 p0, lnlike0, lnprob0 = y, newlnlike, newlnprob
+                if self.n_metaparams == 8:
+                    lnlike1, lnlike2, lnprob1, lnprob2 = newlnlike1, newlnlike2, newlnprob1, newlnprob2
 
                 # update acceptance counter
                 self.naccepted += 1
                 self.jumpDict[jump_name][1] += 1
-        # temperature swap
-        if iter % self.Tskip == 0 and self.nchain > 1:
-            p0, lnlike0, lnprob0 = self.PTswap(p0, lnlike0, lnprob0, iter)
+        
+        # Update chains
+        if self.n_metaparams == 8: # MSTI
+            self.updateChains(p0, lnlike0, lnprob0, iter, lnlike1=lnlike1, lnprob1=lnprob1, lnlike2=lnlike2, lnprob2=lnprob2)
+            return p0, lnlike0, lnprob0, lnlike1, lnprob1, lnlike2, lnprob2
+            
+        else:
+            # temperature swap
+            if iter % self.Tskip == 0 and self.nchain > 1: 
+                p0, lnlike0, lnprob0 = self.PTswap(p0, lnlike0, lnprob0, iter) # No temperature swap for model-switch TI
+            
+            self.updateChains(p0, lnlike0, lnprob0, iter)
+            
+            return p0, lnlike0, lnprob0
 
-        self.updateChains(p0, lnlike0, lnprob0, iter)
-
-        return p0, lnlike0, lnprob0
-
+        
     def PTswap(self, p0, lnlike0, lnprob0, iter):
         """
-        Do parallel tempering swap.
-
-        (Repurposed from Neil Cornish/Bence Becsy's code)
-
-        Swap acceptance rates are computed per chain by storing
-        the number of swaps proposed and accepted. Since swaps
-        are proposed for every chain, swapProposed is always
-        incremented and nswap_accepted will be incremented only
-        for chains that have the swap accepted. The swap acceptance
-        is calculated elsewhere.
+        Do parallel tempering swap. This feature is not compatible with MSTI
 
         @param p0: current parameter vector
         @param lnlike0: current log-likelihood
@@ -654,12 +810,12 @@ class PTSampler(object):
         @return lnlike0: new log-likelihood
         @return lnprob0: new log posterior value
 
+        Repurposed from Neil Cornish/Bence Becsy's code:
         """
-        Ts = self.ladder
+        Ts = self.ladder # as beta
 
         log_Ls = self.comm.gather(lnlike0, root=0)  # list of likelihoods from each chain
         p0s = self.comm.gather(p0, root=0)  # list of parameter arrays from each chain
-        swap_accepted = np.zeros(self.nchain)
 
         if self.MPIrank == 0:
             # set up map to help keep track of swaps
@@ -668,15 +824,21 @@ class PTSampler(object):
             # loop through and propose a swap at each chain (starting from hottest chain and going down in T)
             # and keep track of results in swap_map
             for swap_chain in reversed(range(self.nchain - 1)):
-                log_acc_ratio = -log_Ls[swap_map[swap_chain]] / Ts[swap_chain]
-                log_acc_ratio += -log_Ls[swap_map[swap_chain + 1]] / Ts[swap_chain + 1]
-                log_acc_ratio += log_Ls[swap_map[swap_chain + 1]] / Ts[swap_chain]
-                log_acc_ratio += log_Ls[swap_map[swap_chain]] / Ts[swap_chain + 1]
+
+                log_acc_ratio = -log_Ls[swap_map[swap_chain]] * Ts[swap_chain]
+                log_acc_ratio += -log_Ls[swap_map[swap_chain + 1]] * Ts[swap_chain + 1]
+                log_acc_ratio += log_Ls[swap_map[swap_chain + 1]] * Ts[swap_chain]
+                log_acc_ratio += log_Ls[swap_map[swap_chain]] * Ts[swap_chain + 1]
 
                 acc_ratio = np.exp(log_acc_ratio)
+                
+                
                 if self.stream.uniform() <= acc_ratio:
                     swap_map[swap_chain], swap_map[swap_chain + 1] = swap_map[swap_chain + 1], swap_map[swap_chain]
-                    swap_accepted[swap_chain] += 1
+                    self.nswap_accepted += 1
+                    self.swapProposed += 1
+                else:
+                    self.swapProposed += 1
 
             # loop through the chains and record the new samples and log_Ls
             for j in range(self.nchain):
@@ -686,42 +848,67 @@ class PTSampler(object):
         # broadcast the new samples and log_Ls to all chains
         p0 = self.comm.scatter(p0s, root=0)
         lnlike0 = self.comm.scatter(log_Ls, root=0)
-        self.nswap_accepted += self.comm.scatter(swap_accepted, root=0)
-        self.swapProposed += 1
 
         # calculate new posterior values
-        lnprob0 = 1 / self.temp * lnlike0 + self.logp(p0)
+        lnprob0 = self.beta * lnlike0 + self.logp(p0)
 
         return p0, lnlike0, lnprob0
 
-    def temperatureLadder(self, Tmin, Tmax=None, tstep=None):
-        """
-        Method to compute temperature ladder. At the moment this uses
-        a geometrically spaced temperature ladder with a temperature
-        spacing designed to give 25 % temperature swap acceptance rate.
 
+    def Ladder(self, Bmax, Bmin=None, tstep=None, shape='geometric'):
+        """
+        Method to compute temperature/beta ladder. The default is a geometrically 
+        spaced ladder with a spacing designed to give 25 % temperature/beta swap 
+        acceptance rate. The other option is a linear spacing, use specifically in 
+        MSTI.
+    
         """
 
         # TODO: make options to do other temperature ladders
 
         if self.nchain > 1:
-            if tstep is None and Tmax is None:
-                tstep = 1 + np.sqrt(2 / self.ndim)
-            elif tstep is None and Tmax is not None:
-                tstep = np.exp(np.log(Tmax / Tmin) / (self.nchain - 1))
-            ladder = np.zeros(self.nchain)
-            for ii in range(self.nchain):
-                ladder[ii] = Tmin * tstep**ii
+            if shape == 'linear':
+                if tstep is None and Bmin is None:  # Bmin set to 0
+                    if Bmin is None:
+                        warnings.warn("Bmin not given. Bmin will be set to 0 for linear spacing.")
+                        Bmin = 0
+                    tstep = Bmax / (self.nchain-1)
+                
+                elif tstep is None and Bmin is not None:
+                    tstep = (Bmax - Bmin) / (self.nchain-1)
+
+                ladder = np.zeros(self.nchain)
+                for ii in range(self.nchain):
+                    ladder[ii] = round(Bmax - (tstep * ii), 5)
+
+            if shape =='geometric':
+                if tstep is None and Bmin is None:
+                    tstep = 1 + np.sqrt(2 / self.ndim)
+                
+                elif tstep is None and Bmin is not None:
+                    if Bmin == 0:
+                        warnings.warn("Bmin set to 0. Geometric series can only approach beta=0. Make sure to include the hot chain to get a beta=0 chain if you haven't already. Bmin will be set to 1e-7.")
+                        Bmin = 1e-7
+                    tstep = np.exp(np.log(Bmin / Bmax) / (1-self.nchain))   ### Bmin can't be 0 here
+                
+                ladder = np.zeros(self.nchain)
+                for ii in range(self.nchain):
+                    ladder[ii] = Bmax * tstep**(-ii)
         else:
-            ladder = np.array([1])
+            ladder = np.array([Bmax])
 
         return ladder
+
+
 
     def _writeToFile(self, iter):
         """
         Function to write chain file. File has ndim+4 columns,
         appended to the parameter values are log-posterior (unnormalized),
-        log-likelihood, acceptance rate, and PT acceptance rate.
+        log-likelihood, acceptance rate, and PT acceptance rate. If doing MSTI
+        there are an additional 4 colums (ndim+8 total), log-posterior of model
+        1, log-likelihood of model 1, log-posterior of model 2, and 
+        log-likelihood of model 2.
         Rates are as of time of writing.
 
         @param iter: Iteration of sampler
@@ -730,24 +917,28 @@ class PTSampler(object):
 
         self._chainfile = open(self.fname, "a+")
         # index 0 is the initial element.  So after 10*thin iterations we need to write elements 1..10
-        write_end = iter // self.thin + 1  # First element not to write.
+        write_end = iter // self.thin + 1 # First element not to write.
         for ind in range(self.ind_next_write, write_end):
             pt_acc = 1
             if self.MPIrank < self.nchain - 1 and self.swapProposed != 0:
                 pt_acc = self.nswap_accepted / self.swapProposed
 
             self._chainfile.write("\t".join(["%22.22f" % (self._chain[ind, kk]) for kk in range(self.ndim)]))
-            self._chainfile.write(
-                "\t%f\t%f\t%f\t%f\n"
-                % (self._lnprob[ind], self._lnlike[ind], self.naccepted / iter if iter > 0 else 0, pt_acc)
-            )
+            self._chainfile.write("\t%f\t%f" % (self._lnprob[ind], self._lnlike[ind]))
+            
+            if self.n_metaparams == 8: # MSTI
+                self._chainfile.write("\t%f\t%f\t%f\t%f" % (self._lnprob1[ind], self._lnlike1[ind], self._lnprob2[ind], self._lnlike2[ind]))
+                
+            self._chainfile.write("\t%f\t%f\n" % (self.naccepted / iter if iter > 0 else 0, pt_acc))
+            
         self._chainfile.close()
-        self.ind_next_write = write_end  # Ready for next write
+        self.ind_next_write = write_end # Ready for next write
 
         # write jump statistics files ####
 
         # only for T=1 chain
         if self.MPIrank == 0:
+
             # first write file contaning jump names and jump rates
             fout = open(self.outDir + "/jumps.txt", "w")
             njumps = len(self.propCycle)
@@ -772,7 +963,7 @@ class PTSampler(object):
         @param mem: Number of steps between updates
 
         """
-
+        #breakpoint()
         it = iter - mem
         ndim = self.ndim
 
@@ -784,6 +975,7 @@ class PTSampler(object):
             diff = np.zeros(ndim)
             it += 1
             for jj in range(ndim):
+
                 diff[jj] = self._AMbuffer[ii, jj] - self.mu[jj]
                 self.mu[jj] += diff[jj] / it
 
@@ -815,7 +1007,7 @@ class PTSampler(object):
         self._DEbuffer[-len(self._AMbuffer) :] = self._AMbuffer  # add new samples to the new empty spaces
 
     # SCAM jump
-    def covarianceJumpProposalSCAM(self, x, iter, beta):
+    def covarianceJumpProposalSCAM(self, x, iter, beta):   #maybe include a TI argument to avoid temp scaling??
         """
         Single Component Adaptive Jump Proposal. This function will occasionally
         jump in more than 1 parameter. It will also occasionally use different
@@ -832,7 +1024,7 @@ class PTSampler(object):
 
         q = x.copy()
         qxy = 0
-
+        
         # choose group
         jumpind = self.stream.integers(0, len(self.groups))
         ndim = len(self.groups[jumpind])
@@ -850,14 +1042,15 @@ class PTSampler(object):
 
         # small-medium jump
         # elif prob > 0.6:
+        #   scale = 0.5
 
         # standard medium jump
         else:
             scale = 1.0
 
-        # adjust scale based on temperature
-        if self.temp <= 100:
-            scale *= np.sqrt(self.temp)
+        # adjust scale based on beta  
+        # if self.beta >= 0.01:
+        #     scale *= 1/np.sqrt(self.beta)
 
         # get parmeters in new diagonalized basis
         # y = np.dot(self.U.T, x[self.covinds])
@@ -866,7 +1059,7 @@ class PTSampler(object):
         ind = np.unique(self.stream.integers(0, ndim, 1))
         neff = len(ind)
         cd = 2.4 / np.sqrt(2 * neff) * scale
-
+        
         q[self.groups[jumpind]] += (
             self.stream.standard_normal() * cd * np.sqrt(self.S[jumpind][ind]) * self.U[jumpind][:, ind].flatten()
         )
@@ -874,7 +1067,7 @@ class PTSampler(object):
         return q, qxy
 
     # AM jump
-    def covarianceJumpProposalAM(self, x, iter, beta):
+    def covarianceJumpProposalAM(self, x, iter, beta):  #maybe include a TI argument to avoid temp scaling??
         """
         Adaptive Jump Proposal. This function will occasionally
         use different jump sizes to ensure proper mixing.
@@ -890,7 +1083,7 @@ class PTSampler(object):
 
         q = x.copy()
         qxy = 0
-
+        
         # choose group
         jumpind = self.stream.integers(0, len(self.groups))
 
@@ -913,9 +1106,9 @@ class PTSampler(object):
         else:
             scale = 1.0
 
-        # adjust scale based on temperature
-        if self.temp <= 100:
-            scale *= np.sqrt(self.temp)
+        # adjust scale based on beta 
+        # if self.beta >= 0.01:
+        #     scale *= 1/np.sqrt(self.beta)
 
         # get parmeters in new diagonalized basis
         y = np.dot(self.U[jumpind].T, x[self.groups[jumpind]])
@@ -924,14 +1117,14 @@ class PTSampler(object):
         ind = np.arange(len(self.groups[jumpind]))
         neff = len(ind)
         cd = 2.4 / np.sqrt(2 * neff) * scale
-
+        
         y[ind] = y[ind] + self.stream.standard_normal(neff) * cd * np.sqrt(self.S[jumpind][ind])
         q[self.groups[jumpind]] = np.dot(self.U[jumpind], y)
 
         return q, qxy
 
     # Differential evolution jump
-    def DEJump(self, x, iter, beta):
+    def DEJump(self, x, iter, beta):    #maybe include a TI argument to avoid temp scaling??
         """
         Differential Evolution Jump. This function will  occasionally
         use different jump sizes to ensure proper mixing.
@@ -966,14 +1159,17 @@ class PTSampler(object):
         # get jump scale size
         prob = self.stream.random()
 
-        # mode jump
-        if prob > 0.5:
-            scale = 1.0
+        # mode jump     #maybe include a TI argument to avoid temp scaling??
+        # if prob > 0.5:
+        #     scale = 1.0
 
-        else:
-            scale = self.stream.random() * 2.4 / np.sqrt(2 * ndim) * np.sqrt(1 / beta)
+        # else:     #maybe include a TI argument to avoid temp scaling??
+        #     scale = self.stream.random() * 2.4 / np.sqrt(2 * ndim) * np.sqrt(1 / self.beta)
+
+        scale = 1.0
 
         for ii in range(ndim):
+
             # jump size
             sigma = self._DEbuffer[mm, self.groups[jumpind][ii]] - self._DEbuffer[nn, self.groups[jumpind][ii]]
 
@@ -1054,12 +1250,12 @@ class PTSampler(object):
 
         # call function
         ind = self.stream.integers(0, length)
-        q, qxy = self.propCycle[ind](x, iter, 1 / self.temp)
+        q, qxy = self.propCycle[ind](x, iter, self.beta)
 
         # axuilary jump
         if len(self.aux) > 0:
             for aux in self.aux:
-                q, qxy_aux = aux(x, q, iter, 1 / self.temp)
+                q, qxy_aux = aux(x, q, iter, self.beta)
                 qxy += qxy_aux
 
         return q, qxy, self.propCycle[ind].__name__

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -231,7 +231,6 @@ class PTSampler(object):
 
 
         """
-        #breakpoint()
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
             maxIter = Niter
@@ -332,13 +331,7 @@ class PTSampler(object):
             raise ValueError("No jump proposals specified!")
 
         # randomize cycle
-        self.randomizeProposalCycle()
-
-        # Hot chains required for MSTI         
-        # if self.n_metaparams == 8:
-        #     #hotChain=True
-        #     #writeHotChains=True
-        #     shape = 'linear'  
+        self.randomizeProposalCycle() 
             
         # if ladder given check if in temp or beta
         if self.ladder:
@@ -748,7 +741,6 @@ class PTSampler(object):
             # update acceptance counter
             self.naccepted = iter * self.resumechain[iter//self.thin, -2]
         else:
-            #breakpoint()
             y, qxy, jump_name = self._jump(p0, iter) # made a jump
             self.jumpDict[jump_name][0] += 1
 
@@ -884,8 +876,7 @@ class PTSampler(object):
         """
         Method to compute temperature/beta ladder. The default is a geometrically 
         spaced ladder with a spacing designed to give 25 % temperature/beta swap 
-        acceptance rate. The other option is a linear spacing, use specifically in 
-        MSTI.
+        acceptance rate. The other option is a linear spacing.
     
         """
 
@@ -988,7 +979,6 @@ class PTSampler(object):
         @param mem: Number of steps between updates
 
         """
-        #breakpoint()
         it = iter - mem
         ndim = self.ndim
 
@@ -1032,7 +1022,7 @@ class PTSampler(object):
         self._DEbuffer[-len(self._AMbuffer) :] = self._AMbuffer  # add new samples to the new empty spaces
 
     # SCAM jump
-    def covarianceJumpProposalSCAM(self, x, iter, beta):   #maybe include a TI argument to avoid temp scaling??
+    def covarianceJumpProposalSCAM(self, x, iter, beta): 
         """
         Single Component Adaptive Jump Proposal. This function will occasionally
         jump in more than 1 parameter. It will also occasionally use different
@@ -1092,7 +1082,7 @@ class PTSampler(object):
         return q, qxy
 
     # AM jump
-    def covarianceJumpProposalAM(self, x, iter, beta):  #maybe include a TI argument to avoid temp scaling??
+    def covarianceJumpProposalAM(self, x, iter, beta):  
         """
         Adaptive Jump Proposal. This function will occasionally
         use different jump sizes to ensure proper mixing.
@@ -1149,7 +1139,7 @@ class PTSampler(object):
         return q, qxy
 
     # Differential evolution jump
-    def DEJump(self, x, iter, beta):    #maybe include a TI argument to avoid temp scaling??
+    def DEJump(self, x, iter, beta):  
         """
         Differential Evolution Jump. This function will  occasionally
         use different jump sizes to ensure proper mixing.
@@ -1184,11 +1174,11 @@ class PTSampler(object):
         # get jump scale size
         prob = self.stream.random()
 
-        # mode jump     #maybe include a TI argument to avoid temp scaling??
+        # mode jump    
         # if prob > 0.5:
         #     scale = 1.0
 
-        # else:     #maybe include a TI argument to avoid temp scaling??
+        # else:   
         #     scale = self.stream.random() * 2.4 / np.sqrt(2 * ndim) * np.sqrt(1 / self.beta)
 
         scale = 1.0


### PR DESCRIPTION
Model-Switch Thermodynamic Integration (MSTI) feature has been added, allowing users to sample across the posteriors of two models, instead of sampling between each model's prior and posterior, individually. Beta=0 is the posterior of model 0 and beta=1 is the posterior of model 1. A beta in between 0 and 1 is a mixture of the two models’ posterior distributions. Changes include the ability to give PTMCMC a tuple of prior and likelihood functions, a new parameter for a tuple of lists of indices for each model’s parameters used to sift through the combined set of parameters in p0, and a parameter to indicate the preferred ladder shape (only geometric or linear as of right now). When using MSTI, four additional columns are written in the chain file -- the log posterior and log likelihood of the two models being compared.  

Instances of 1/temperature have been replaced by beta. Changes include PTMCMC accepting beta max and beta min (while still accepting Tmin and Tmax), chain files named with beta instead of temperature, and a parameter to indicate whether the temperature naming convention should be use instead.

Temperature scaling has been commented out since for hot chains it produces massive and frequently invalid jumps.